### PR TITLE
Backport tokio-io-timeout 0.3 update to 0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ hyper = "0.11"
 tokio-core = "0.1"
 tokio-io = "0.1"
 tokio-service = "0.1"
-tokio-io-timeout = "0.1"
+tokio-io-timeout = "0.3"
 
 [dev-dependencies]
 native-tls = "0.1"


### PR DESCRIPTION
tokio-io-timeout 0.1 does not build any more.

I had to create the PR against master because you don't have a 0.1 branch.