### PR TITLE
Remove unused dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ travis-ci = { repository = "https://github.com/hjr3/hyper-timeout", branch = "ma
 bytes = "0.5"
 hyper = { version = "0.13", default-features = false, features = ["tcp"] }
 tokio = "0.2"
-tokio-io = "0.1"
 tokio-io-timeout = "0.4"
 
 [dev-dependencies]


### PR DESCRIPTION
tokio-io v0.1 is listed as a dependency but is never used, so it can be removed