### PR TITLE
Cleanup dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,13 @@ readme = "README.md"
 
 [dependencies]
 bytes = "1.0.0"
-hyper = { version = "0.14", default-features = false, features = ["client", "http1", "tcp"] }
+hyper = { version = "0.14.2", features = ["client"] }
 pin-project-lite = "0.2"
 tokio = "1.0.0"
 tokio-io-timeout = "1.0.1"
 
 [dev-dependencies]
+hyper = { version = "0.14", features = ["client", "http1", "tcp"] }
 #FIXME enable when https://github.com/hyperium/hyper-tls/pull/79 lands
 #hyper-tls = "0.4"
 tokio = { version = "1.0.0", features = ["io-std", "io-util", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/hjr3/hyper-timeout"
 readme = "README.md"
 
 [dependencies]
-bytes = "1.0.0"
 hyper = { version = "0.14.2", features = ["client"] }
 pin-project-lite = "0.2"
 tokio = "1.0.0"


### PR DESCRIPTION
- e37d0f7981949e200a71db27e51007efedd53eff: Remove dependency on `hyper`'s `http1` and `tcp` features by default

[hyper v0.14.2](https://github.com/hyperium/hyper/releases/tag/v0.14.2) exposed `connect` types without `http1`/`http2` features so they are not required anymore.

- 69f5d452b10c44ce81625435a08e209aa21f473d: Remove `bytes` dependency

`bytes` does not appear in trait bounds of `tokio::io::Async{Read,Write}` methods anymore so the dependency can be removed.