### PR TITLE
Update to hyper-tls 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,5 @@ tokio-io-timeout = "1.1.0"
 
 [dev-dependencies]
 hyper = { version = "0.14", features = ["client", "http1", "tcp"] }
-#FIXME enable when https://github.com/hyperium/hyper-tls/pull/79 lands
-#hyper-tls = "0.4"
+hyper-tls = "0.5"
 tokio = { version = "1.0.0", features = ["io-std", "io-util", "macros"] }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -4,8 +4,7 @@ use std::time::Duration;
 use hyper::{body::HttpBody as _, Client};
 use tokio::io::{self, AsyncWriteExt as _};
 
-use hyper::client::HttpConnector;
-//use hyper_tls::HttpsConnector;
+use hyper_tls::HttpsConnector;
 
 use hyper_timeout::TimeoutConnector;
 
@@ -23,8 +22,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let url = url.parse::<hyper::Uri>().unwrap();
 
     // This example uses `HttpsConnector`, but you can also use hyper `HttpConnector`
-    let h = HttpConnector::new();
-    //let h = HttpsConnector::new();
+    //let h = hyper::client::HttpConnector::new();
+    let h = HttpsConnector::new();
     let mut connector = TimeoutConnector::new(h);
     connector.set_connect_timeout(Some(Duration::from_secs(5)));
     connector.set_read_timeout(Some(Duration::from_secs(5)));


### PR DESCRIPTION
This allows the example client to use the HttpsConnector.